### PR TITLE
cleanup() breaks.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-
 /**
  * Module dependencies
  */
@@ -60,7 +59,7 @@ function jsonp(url, opts, fn){
   }
 
   function cleanup(){
-    target.parentNode.removeChild(script);
+    script.parentNode.removeChild(script);
     window['__jp' + id] = noop;
   }
 


### PR DESCRIPTION
I was enjoying `jsonp()` when i noticed `cleanup()` breaks because it attempts to get a `.parentNode` of a script that doesn't exist.

You can reproduce this with:

``` js

var jsonp = require('jsonp');

jsonp('https://www.googleapis.com/freebase/v1/text/en/bob_dylan', function(){
  console.log(arguments);
});

jsonp('https://www.googleapis.com/freebase/v1/text/en/bob_dylan', function(){
  console.log(arguments);
});

```

One of those will fail to execute with the error `Uncaught TypeError: Cannot call method 'removeChild' of null`
