### PR TITLE
fallback to document.head if there is not any script tags in the dom

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ function jsonp(url, opts, fn){
   var param = opts.param || 'callback';
   var timeout = null != opts.timeout ? opts.timeout : 60000;
   var enc = encodeURIComponent;
-  var target = document.getElementsByTagName('script')[0];
+  var target = document.getElementsByTagName('script')[0] || document.head;
   var script;
   var timer;
 


### PR DESCRIPTION
I did run in to a bug when the `target` was `undefined`.
