### PR TITLE
remove default target value 'document.head'

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ function jsonp(url, opts, fn){
   var param = opts.param || 'callback';
   var timeout = null != opts.timeout ? opts.timeout : 60000;
   var enc = encodeURIComponent;
-  var target = document.getElementsByTagName('script')[0] || document.head;
+  var target = document.getElementsByTagName('script')[0];
   var script;
   var timer;
 


### PR DESCRIPTION
Removes unreachable `document.head` reference, because there always will be a script-tag when it is executed in a browser.
