### PR TITLE
Return fn to cancel in-progress jsonp request

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -34,6 +34,9 @@ The callback is called with `err, data` parameters.
 If it times out, the `err` will be an `Error` object whose `message` is
 `Timeout`.
 
+Returns a function that, when called, will cancel the in-progress jsonp request
+(`fn` won't be called).
+
 ## License
 
 MIT

--- a/index.js
+++ b/index.js
@@ -62,11 +62,17 @@ function jsonp(url, opts, fn){
   function cleanup(){
     script.parentNode.removeChild(script);
     window[id] = noop;
+    if (timer) clearTimeout(timer);
+  }
+
+  function cancel(){
+    if (window[id]) {
+      cleanup();
+    }
   }
 
   window[id] = function(data){
     debug('jsonp got', data);
-    if (timer) clearTimeout(timer);
     cleanup();
     if (fn) fn(null, data);
   };
@@ -81,4 +87,6 @@ function jsonp(url, opts, fn){
   script = document.createElement('script');
   script.src = url;
   target.parentNode.insertBefore(script, target);
+
+  return cancel;
 }


### PR DESCRIPTION
When destroying a page component, for example a video player, it’s
important to be able to cancel in-flight jsonp requests so the callback
doesn’t get called and all references to the player will be nulled so
the player can get garbage collected quickly.

If the callback were to hang around for another few seconds, this would
delay GC and call a function that assumes the player is in a good state
when it’s not.
