### PR TITLE
Make sure script.parentNode exists before removing the script element

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ function jsonp(url, opts, fn){
   }
 
   function cleanup(){
-    script.parentNode.removeChild(script);
+    if (script.parentNode) script.parentNode.removeChild(script);
     window[id] = noop;
     if (timer) clearTimeout(timer);
   }


### PR DESCRIPTION
When creating a lot of JSONP requests, I observed that sometimes parentNode is undefined and it causes some uncaught exceptions.
