### PR TITLE
loose debug version

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "A sane JSONP implementation.",
   "version": "0.2.0",
   "dependencies": {
-    "debug": "2.1.3"
+    "debug": "^2.1.3"
   },
   "component": {
     "scripts": {


### PR DESCRIPTION
could we loose the debug version to something like `^2.0.0` as we are using webpack, the client side require different version of the package might potentially increase the js size if we cannot dedup by the dedup webpack plugin. (so does the server side package size)

Thanks
