### PR TITLE
Add licence information in the package.json file

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "jsonp",
   "description": "A sane JSONP implementation.",
   "version": "0.2.1",
+  "license": "MIT",
   "dependencies": {
     "debug": "^2.1.3"
   },


### PR DESCRIPTION
Hi,

I use ScalaJS and to declare JS dependencies in ScalaJS, I need to pass through webjars (http://www.webjars.org/). 
So, to be able to use your lib in ScalaJS (I don't really use your lib, it's a lib I use that uses your lib 😉),  I need to import you lib from NPM to webjars (possible via the UI of webjars).
But because of licence reason, webjars refuses to import it:
![capture d ecran 2017-04-08 12 14 14](https://cloud.githubusercontent.com/assets/1193670/24828016/e881a4e2-1c54-11e7-94e7-41ba519d1e00.png)

So, is it possible or you to merge this PR and publish a 0.2.2 version ?

Thanks :)