### PR TITLE
Address caching issue where callback URLs aren't unique if the counter is ever reset

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,8 +46,10 @@ function jsonp(url, opts, fn){
   var prefix = opts.prefix || '__jp';
 
   // use the callback name that was passed if one was provided.
-  // otherwise generate a unique name by incrementing our counter.
-  var id = opts.name || (prefix + (count++));
+  // otherwise generate a unique name by using the current timestamp
+  var currentTime = new Date().getTime();
+  var id = opts.name || (prefix + currentTime);
+  count++;
 
   var param = opts.param || 'callback';
   var timeout = null != opts.timeout ? opts.timeout : 60000;


### PR DESCRIPTION
I have an Electron-based app which is using this to pull data from an API at regular intervals. I came across the issue where closing & reopening the app had the data being returned using the old data from the last session.

Upon investigation, it appears this is due to the fact that the callback that this is implementing has a counter that is then reset when the app is restarted, and this is leading it to try and display that previously retrieved data even with Electron set to not utilize cache.

The simple fix is to have it use the current timestamp rather than a session-based counter. I'd love to see this implemented in a  future version as this addresses an issue I had come across that I'm thinking others might be experiencing as well.